### PR TITLE
Fix nth-child() by check previousElementSibling

### DIFF
--- a/src/dom-element-path.js
+++ b/src/dom-element-path.js
@@ -3,7 +3,11 @@ const parentElements = (element) => {
   while (element) {
     const tagName = element.nodeName.toLowerCase();
     const cssId = element.id ? `#${element.id}` : '';
-    const cssClass = element.className ? `.${element.className.replace(/\s+/g, '.')}` : '';
+    let cssClass = '';
+    if (element.className && typeof element.className === 'string') {
+      // escape class names
+      cssClass = `.${element.className.replace(/\s+/g, '.').replace(/[:*+?^${}()|[\]\\]/gi, '\\$&')}`;
+    }
 
     parents.unshift({
       element,

--- a/src/dom-element-path.js
+++ b/src/dom-element-path.js
@@ -20,7 +20,7 @@ const nthElement = (element) => {
   let c = element;
   let nth = 1;
   while (c.previousElementSibling !== null) {
-    if (c.nodeName === element.nodeName) {
+    if (c.previousElementSibling.nodeName === element.nodeName) {
       nth++;
     }
     c = c.previousElementSibling;

--- a/src/dom-element-path.test.js
+++ b/src/dom-element-path.test.js
@@ -88,6 +88,22 @@ describe('domElementPath', () => {
     expect(result).toBe('html > body > div.a.b:nth-of-type(2)');
   });
 
+  test('it should add nth-of-type selector to same elements without using the incorrect nth-of-type increment', () => {
+    const div1 = document.createElement('div');
+    const div2 = document.createElement('div');
+    const p1 = document.createElement('p');
+    const p2 = document.createElement('p');
+
+    document.body.appendChild(div1);
+    document.body.appendChild(div2);
+    document.body.appendChild(p1);
+    document.body.appendChild(p2);
+
+    const result = domElementPath(p1);
+
+    expect(result).toBe('html > body > p:nth-of-type(1)');
+  });
+
   test('it should not add nth-of-type selector to different elements with same class of same parent', () => {
     const div = document.createElement('div');
     div.setAttribute('class', 'a b');
@@ -128,5 +144,16 @@ describe('domElementPath', () => {
     const result = domElementPath(div1);
 
     expect(result).toBe('html > body > div#some-id.a.b');
+  });
+
+  test('it should escape class names', () => {
+    const div1 = document.createElement('div');
+    div1.setAttribute('class', 'a:b');
+
+    document.body.appendChild(div1);
+
+    const result = domElementPath(div1);
+
+    expect(result).toBe('html > body > div.a\\:b');
   });
 });


### PR DESCRIPTION
This is necessary as in some cases such as:
```js
<p></p>
<p></p>
<div></div>
<div></div>
```

It will miscount the nth-child.