### PR TITLE
Add exports for utils and give option for type (nthElement vs nthOfType)

### DIFF
--- a/src/dom-element-path.js
+++ b/src/dom-element-path.js
@@ -20,6 +20,8 @@ const parentElements = (element) => {
   return parents;
 };
 
+export { parentElements };
+
 const nthElement = (element) => {
   let c = element;
   let nth = 1;
@@ -32,6 +34,8 @@ const nthElement = (element) => {
 
   return nth;
 };
+
+export { nthElement };
 
 const nthSelectorNeeded = (selector, path) => {
   const querySelector = path === '' ? selector : `${path} > ${selector}`;

--- a/src/dom-element-path.js
+++ b/src/dom-element-path.js
@@ -22,11 +22,11 @@ const parentElements = (element) => {
 
 export { parentElements };
 
-const nthElement = (element) => {
+const nthElement = (element, sameType = true) => {
   let c = element;
   let nth = 1;
   while (c.previousElementSibling !== null) {
-    if (c.previousElementSibling.nodeName === element.nodeName) {
+    if (!sameType || c.previousElementSibling.nodeName === element.nodeName) {
       nth++;
     }
     c = c.previousElementSibling;


### PR DESCRIPTION
These changes make it possible to use this package for multiple use cases as the utils would be accessible.
Until now `nthElement` gave back the nthOfType selector compared to CSS selectors. This might be confusing. So I added an option for nth-of-type (which is true as a default), which is not a breaking change, but adds the possibility to get nth-of-type as well as nth-child.