### PR TITLE
fix: element is not a valid selector

### DIFF
--- a/src/dom-element-path.js
+++ b/src/dom-element-path.js
@@ -6,7 +6,10 @@ const parentElements = (element) => {
     let cssClass = '';
     if (element.className && typeof element.className === 'string') {
       // escape class names
-      cssClass = `.${element.className.replace(/\s+/g, '.').replace(/[:*+?^${}()|[\]\\]/gi, '\\$&')}`;
+      cssClass = `.${element.className
+          .trim()
+          .replace(/\s+/g, '.')
+          .replace(/[:*+?^${}()|[\]\\]/gi, '\\$&')}`;
     }
 
     parents.unshift({

--- a/src/dom-element-path.test.js
+++ b/src/dom-element-path.test.js
@@ -156,4 +156,15 @@ describe('domElementPath', () => {
 
     expect(result).toBe('html > body > div.a\\:b');
   });
+
+  test('it should escape space effects', () => {
+      const div1 = document.createElement('div');
+      div1.setAttribute('class', 'a ');
+
+      document.body.appendChild(div1);
+
+      const result = domElementPath(div1);
+
+      expect(result).toBe('html > body > div.a');
+  });
 });


### PR DESCRIPTION
修复当 class 属性出现多余空格时报错

```html
<div class="gda-modal-wrap "></div>
```
```js
Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Document': 'html > body > div.div1 > div.div2 > div.gda-modal-wrap.' is not a valid selector.
```